### PR TITLE
Update requirements.txt to include transformers to load a local LLM

### DIFF
--- a/labs/DataDialogue/requirements.txt
+++ b/labs/DataDialogue/requirements.txt
@@ -7,3 +7,4 @@ huggingface-hub
 redis
 streamlit-image-select
 requests
+transformers


### PR DESCRIPTION
### Description

Adding https://pypi.org/project/transformers/ to load a local LLM . This needs to be given as an option to end users along with openAI for folks to load and run a local LLM when they have good memory along with GPUs lcoally and they are sensitive to data privacy and want data not leaving their machines

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `master` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
