### PR TITLE
Update requirements.txt to downgrade transformers to support 8 bit quantization

### DIFF
--- a/labs/DataDialogue/requirements.txt
+++ b/labs/DataDialogue/requirements.txt
@@ -7,4 +7,4 @@ huggingface-hub
 redis
 streamlit-image-select
 requests
-transformers
+transformers==4.30

--- a/labs/DataDialogue/requirements.txt
+++ b/labs/DataDialogue/requirements.txt
@@ -8,3 +8,6 @@ redis
 streamlit-image-select
 requests
 transformers==4.30
+accelerate
+bitsandbytes
+torch


### PR DESCRIPTION
Downgrading transformers to support 8 bit quantization on my M1 mac 

Filed issue https://github.com/TimDettmers/bitsandbytes/issues/749

### Description

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `master` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
