### PR TITLE
fix: Update install.py to remove sam package run failure

### DIFF
--- a/install.py
+++ b/install.py
@@ -16,7 +16,7 @@ def main():
         print()
         print ('packaging trapheus for use ...')
         try:
-            subprocess.run(package_command, shell=False, check=True)
+            subprocess.run(package_command, shell=True, check=True)
         except subprocess.CalledProcessError as e:
             print(f'Error: {e}')
 
@@ -46,7 +46,7 @@ def main():
     print()
     print('Deploying trapheus to AWS ...')
     try:
-        subprocess.run(deploy_command, shell=False, check=True)
+        subprocess.run(deploy_command, shell=True, check=True)
     except subprocess.CalledProcessError as e:
         print(f'Error: {e}')
 


### PR DESCRIPTION
### Description

this PR fixes broken changes in install.py that caused failure in formation of the Trapheus CFT

`    subprocess.run([package_command], shell=False, check=True)
  File "/opt/homebrew/Cellar/python@3.11/3.11.5/Frameworks/Python.framework/Versions/3.11/lib/python3.11/subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.5/Frameworks/Python.framework/Versions/3.11/lib/python3.11/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/opt/homebrew/Cellar/python@3.11/3.11.5/Frameworks/Python.framework/Versions/3.11/lib/python3.11/subprocess.py", line 1950, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'sam package --template-file template.yaml --output-template-file deploy.yaml --s3-bucket abc --region us-west-2'`

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `master` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
