### PR TITLE
Adding support for CUDA

### DIFF
--- a/labs/TrapheusAI/Dockerfile.cuda
+++ b/labs/TrapheusAI/Dockerfile.cuda
@@ -1,0 +1,21 @@
+FROM nvidia/cuda:11.1.1-cudnn8-runtime-ubuntu20.04
+
+
+WORKDIR /app
+
+
+RUN apt-get update && \
+    apt-get install -y python3-pip && \
+    pip3 install streamlit torch torchvision
+
+RUN git clone https://github.com/intuit/Trapheus .
+
+cd labs/TrapheusAI
+
+RUN pip3 install -r requirements.txt
+
+EXPOSE 8501
+
+HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
+
+ENTRYPOINT ["streamlit", "run", "trapheusai_app.py", "--server.port=8501", "--server.address=0.0.0.0"]


### PR DESCRIPTION
### Description

Adding support for CUDA

To build the image:
docker build -t Dockefile.cuda .

Run the conatiner
docker run --gpus all -p 8501:8501 Dockefile.cuda

--gpus all will enable gpu support for the container

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `master` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
