### PR TITLE
Update template.yaml to remove tags from lambda layer

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -184,8 +184,6 @@ Resources:
         - python3.7
         - python3.6
       LicenseInfo: 'MIT'
-      Tags:
-        AppComponent: "SecurityGroup"
 
   RenameLambdaFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
AWS lambda layer does not support tagging, hence removing this to avoid deployment failure.

### Description

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `master` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
