### PR TITLE
fix: upgrade AWS Lambda runtime from python3.8 to python3.11

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -338,7 +338,7 @@ Resources:
                   nextStep: CreateDBInstance
                   isEnd: false
                   inputs:
-                    Runtime: python3.8
+                    Runtime: python3.11
                     Handler: script_handler
                     Script: |-
                       def script_handler(events, context):


### PR DESCRIPTION
Fixes #225

### Description

The deployment currently fails with an 'Invalid request' error because  python3.8 is no longer a supported runtime for new resource updates. 

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `master` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
